### PR TITLE
Resolves #9 and #11: Configurable Ollama host and port

### DIFF
--- a/README.md
+++ b/README.md
@@ -266,7 +266,7 @@ Installing dependencies via `install_deps.sh` is recommended to improve support 
 
 If you encounter connection errors to Ollama:
 1. Check that Ollama is running.
-2. By default, Ollama must be accessible at `http://localhost:11434`. 
+2. By default, Ollama must be accessible at `http://localhost:11434` or the host and port specified by the OLLAMA_HOST environment variable.
 3. If your Ollama instance is running on a different host or port, use the `--host` and `--port` flags:
    ```bash
    rlama --host 192.168.1.100 --port 8000 list

--- a/README.md
+++ b/README.md
@@ -294,3 +294,25 @@ For any other issues, please open an issue on the [GitHub repository](https://gi
 2. The complete output of the command.
 3. Your operating system and architecture.
 4. The RLAMA version (`rlama --version`).
+
+### Configuring Ollama Connection
+
+RLAMA provides multiple ways to connect to your Ollama instance:
+
+1. **Command-line flags** (highest priority):
+   ```bash
+   rlama --host 192.168.1.100 --port 8080 run my-rag
+   ```
+
+2. **Environment variable**:
+   ```bash
+   # Format: "host:port" or just "host"
+   export OLLAMA_HOST=remote-server:8080
+   rlama run my-rag
+   ```
+
+3. **Default values** (used if no other method is specified):
+   - Host: `localhost`
+   - Port: `11434`
+
+The precedence order is: command-line flags > environment variable > default values.

--- a/README.md
+++ b/README.md
@@ -125,6 +125,15 @@ You can get help on all commands by using:
 rlama --help
 ```
 
+### Global Flags
+
+These flags can be used with any command:
+
+```bash
+--host string   Ollama host (default: localhost)
+--port string   Ollama port (default: 11434)
+```
+
 ### rag - Create a RAG system
 
 Creates a new RAG system by indexing all documents in the specified folder.
@@ -257,8 +266,13 @@ Installing dependencies via `install_deps.sh` is recommended to improve support 
 
 If you encounter connection errors to Ollama:
 1. Check that Ollama is running.
-2. Ollama must be accessible at `http://localhost:11434`.
-3. Check Ollama logs for potential errors.
+2. By default, Ollama must be accessible at `http://localhost:11434`. 
+3. If your Ollama instance is running on a different host or port, use the `--host` and `--port` flags:
+   ```bash
+   rlama --host 192.168.1.100 --port 8000 list
+   rlama --host my-ollama-server --port 11434 run my-rag
+   ```
+4. Check Ollama logs for potential errors.
 
 ### Text extraction issues
 

--- a/cmd/add_docs.go
+++ b/cmd/add_docs.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 
 	"github.com/spf13/cobra"
-	"github.com/dontizi/rlama/internal/client"
 	"github.com/dontizi/rlama/internal/service"
 )
 
@@ -21,10 +20,13 @@ and add them to the existing RAG system.`,
 		ragName := args[0]
 		folderPath := args[1]
 
+		// Get Ollama client from root command
+		ollamaClient := GetOllamaClient()
+		
 		// Create necessary services
-		ragService := service.NewRagService()
+		ragService := service.NewRagService(ollamaClient)
 		documentLoader := service.NewDocumentLoader()
-		embeddingService := service.NewEmbeddingService()
+		embeddingService := service.NewEmbeddingService(ollamaClient)
 
 		// Load the RAG
 		rag, err := ragService.LoadRag(ragName)
@@ -33,7 +35,6 @@ and add them to the existing RAG system.`,
 		}
 
 		// Check if Ollama is available with the model
-		ollamaClient := client.NewOllamaClient()
 		if err := ollamaClient.CheckOllamaAndModel(rag.ModelName); err != nil {
 			return err
 		}
@@ -89,4 +90,4 @@ and add them to the existing RAG system.`,
 
 func init() {
 	rootCmd.AddCommand(addDocsCmd)
-} 
+}

--- a/cmd/list_docs.go
+++ b/cmd/list_docs.go
@@ -18,8 +18,11 @@ Example: rlama list-docs my-docs`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		ragName := args[0]
 
+		// Get Ollama client from root command
+		ollamaClient := GetOllamaClient()
+
 		// Create necessary services
-		ragService := service.NewRagService()
+		ragService := service.NewRagService(ollamaClient)
 
 		// Load the RAG
 		rag, err := ragService.LoadRag(ragName)
@@ -71,4 +74,4 @@ func formatSize(size int64) string {
 	default:
 		return fmt.Sprintf("%d B", size)
 	}
-} 
+}

--- a/cmd/rag.go
+++ b/cmd/rag.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/spf13/cobra"
 	"github.com/dontizi/rlama/internal/service"
-	"github.com/dontizi/rlama/internal/client"
 )
 
 var ragCmd = &cobra.Command{
@@ -23,8 +22,8 @@ Supported formats include: .txt, .md, .html, .json, .csv, and various source cod
 		ragName := args[1]
 		folderPath := args[2]
 
-		// Check if Ollama is installed and running
-		ollamaClient := client.NewOllamaClient()
+		// Get Ollama client with configured host and port
+		ollamaClient := GetOllamaClient()
 		if err := ollamaClient.CheckOllamaAndModel(modelName); err != nil {
 			return err
 		}
@@ -33,7 +32,7 @@ Supported formats include: .txt, .md, .html, .json, .csv, and various source cod
 		fmt.Printf("Creating RAG '%s' with model '%s' from folder '%s'...\n", 
 			ragName, modelName, folderPath)
 
-		ragService := service.NewRagService()
+		ragService := service.NewRagService(ollamaClient)
 		err := ragService.CreateRag(modelName, ragName, folderPath)
 		if err != nil {
 			// Improve error messages related to Ollama
@@ -51,4 +50,4 @@ Supported formats include: .txt, .md, .html, .json, .csv, and various source cod
 
 func init() {
 	rootCmd.AddCommand(ragCmd)
-} 
+}

--- a/cmd/remove_doc.go
+++ b/cmd/remove_doc.go
@@ -23,8 +23,11 @@ The document ID is typically the filename. You can see document IDs by using the
 		ragName := args[0]
 		docID := args[1]
 
+		// Get Ollama client from root command
+		ollamaClient := GetOllamaClient()
+
 		// Create necessary services
-		ragService := service.NewRagService()
+		ragService := service.NewRagService(ollamaClient)
 
 		// Load the RAG
 		rag, err := ragService.LoadRag(ragName)
@@ -72,4 +75,4 @@ The document ID is typically the filename. You can see document IDs by using the
 func init() {
 	rootCmd.AddCommand(removeDocCmd)
 	removeDocCmd.Flags().BoolVarP(&forceRemoveDoc, "force", "f", false, "Remove without asking for confirmation")
-} 
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -2,11 +2,10 @@ package cmd
 
 import (
 	"fmt"
-	// Remove or comment these two lines if they're not used
-	// "fmt"
-	// "os"
 
 	"github.com/spf13/cobra"
+	
+	"github.com/dontizi/rlama/internal/client"
 )
 
 const (
@@ -28,17 +27,30 @@ Main commands:
   update                                  Check and install RLAMA updates`,
 }
 
-// Variable to store the version flag
-var versionFlag bool
+// Variables to store command flags
+var (
+	versionFlag bool
+	ollamaHost  string
+	ollamaPort  string
+)
 
 // Execute executes the root command
 func Execute() error {
 	return rootCmd.Execute()
 }
 
+// GetOllamaClient returns an Ollama client configured with host and port from command flags
+func GetOllamaClient() *client.OllamaClient {
+	return client.NewOllamaClient(ollamaHost, ollamaPort)
+}
+
 func init() {
 	// Add --version flag
 	rootCmd.Flags().BoolVarP(&versionFlag, "version", "v", false, "Display RLAMA version")
+	
+	// Add Ollama configuration flags
+	rootCmd.PersistentFlags().StringVar(&ollamaHost, "host", "", "Ollama host (default: localhost)")
+	rootCmd.PersistentFlags().StringVar(&ollamaPort, "port", "", "Ollama port (default: 11434)")
 	
 	// Override the Run function to handle the --version flag
 	rootCmd.Run = func(cmd *cobra.Command, args []string) {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -24,7 +24,10 @@ Main commands:
   run [rag-name]                          Run an existing RAG system
   list                                    List all available RAG systems
   delete [rag-name]                       Delete a RAG system
-  update                                  Check and install RLAMA updates`,
+  update                                  Check and install RLAMA updates
+
+Environment variables:
+  OLLAMA_HOST                            Specifies default Ollama host:port (overridden by --host and --port flags)`,
 }
 
 // Variables to store command flags
@@ -49,8 +52,8 @@ func init() {
 	rootCmd.Flags().BoolVarP(&versionFlag, "version", "v", false, "Display RLAMA version")
 	
 	// Add Ollama configuration flags
-	rootCmd.PersistentFlags().StringVar(&ollamaHost, "host", "", "Ollama host (default: localhost)")
-	rootCmd.PersistentFlags().StringVar(&ollamaPort, "port", "", "Ollama port (default: 11434)")
+	rootCmd.PersistentFlags().StringVar(&ollamaHost, "host", "", "Ollama host (overrides OLLAMA_HOST env var, default: localhost)")
+	rootCmd.PersistentFlags().StringVar(&ollamaPort, "port", "", "Ollama port (overrides port in OLLAMA_HOST env var, default: 11434)")
 	
 	// Override the Run function to handle the --version flag
 	rootCmd.Run = func(cmd *cobra.Command, args []string) {

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/spf13/cobra"
 	"github.com/dontizi/rlama/internal/service"
-	"github.com/dontizi/rlama/internal/client"
 )
 
 var runCmd = &cobra.Command{
@@ -21,13 +20,13 @@ Example: rlama run rag1`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		ragName := args[0]
 
-		// Check if Ollama is installed and running
-		ollamaClient := client.NewOllamaClient()
+		// Get Ollama client with configured host and port
+		ollamaClient := GetOllamaClient()
 		if err := ollamaClient.CheckOllamaAndModel(""); err != nil {
 			return err
 		}
 
-		ragService := service.NewRagService()
+		ragService := service.NewRagService(ollamaClient)
 		rag, err := ragService.LoadRag(ragName)
 		if err != nil {
 			return err
@@ -67,4 +66,4 @@ Example: rlama run rag1`,
 
 func init() {
 	rootCmd.AddCommand(runCmd)
-} 
+}

--- a/cmd/update_model.go
+++ b/cmd/update_model.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 
 	"github.com/spf13/cobra"
-	"github.com/dontizi/rlama/internal/client"
 	"github.com/dontizi/rlama/internal/repository"
 )
 
@@ -21,8 +20,10 @@ recreate the RAG with the new model instead.`,
 		ragName := args[0]
 		newModel := args[1]
 
+		// Get Ollama client from root command
+		ollamaClient := GetOllamaClient()
+		
 		// Check if Ollama is installed and the new model is available
-		ollamaClient := client.NewOllamaClient()
 		if err := ollamaClient.CheckOllamaAndModel(newModel); err != nil {
 			return err
 		}
@@ -53,4 +54,4 @@ recreate the RAG with the new model instead.`,
 
 func init() {
 	rootCmd.AddCommand(updateModelCmd)
-} 
+}

--- a/internal/client/ollama_client.go
+++ b/internal/client/ollama_client.go
@@ -10,6 +10,12 @@ import (
 	"strings"
 )
 
+// Default connection settings for Ollama
+const (
+	DefaultOllamaHost = "localhost"
+	DefaultOllamaPort = "11434"
+)
+
 // OllamaClient est un client pour l'API Ollama
 type OllamaClient struct {
 	BaseURL string

--- a/internal/client/ollama_client.go
+++ b/internal/client/ollama_client.go
@@ -6,11 +6,8 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
-)
-
-const (
-	DefaultOllamaHost = "localhost"
-	DefaultOllamaPort = "11434"
+	"os"
+	"strings"
 )
 
 // OllamaClient est un client pour l'API Ollama
@@ -60,12 +57,33 @@ type GenerationResponse struct {
 
 // NewOllamaClient crée un nouveau client Ollama
 // Si host ou port sont vides, les valeurs par défaut sont utilisées
+// Si OLLAMA_HOST est défini, il est utilisé comme valeur par défaut
 func NewOllamaClient(host, port string) *OllamaClient {
+	// Check for OLLAMA_HOST environment variable
+	ollamaHostEnv := os.Getenv("OLLAMA_HOST")
+	
+	// Default values
+	defaultHost := DefaultOllamaHost
+	defaultPort := DefaultOllamaPort
+	
+	// If OLLAMA_HOST is set, parse it
+	if ollamaHostEnv != "" {
+		// OLLAMA_HOST could be in the form "host:port" or just "host"
+		parts := strings.Split(ollamaHostEnv, ":")
+		if len(parts) >= 1 {
+			defaultHost = parts[0]
+		}
+		if len(parts) >= 2 {
+			defaultPort = parts[1]
+		}
+	}
+	
+	// Command flags override environment variables
 	if host == "" {
-		host = DefaultOllamaHost
+		host = defaultHost
 	}
 	if port == "" {
-		port = DefaultOllamaPort
+		port = defaultPort
 	}
 	
 	baseURL := fmt.Sprintf("http://%s:%s", host, port)

--- a/internal/client/ollama_client.go
+++ b/internal/client/ollama_client.go
@@ -9,7 +9,8 @@ import (
 )
 
 const (
-	DefaultOllamaURL = "http://localhost:11434"
+	DefaultOllamaHost = "localhost"
+	DefaultOllamaPort = "11434"
 )
 
 // OllamaClient est un client pour l'API Ollama
@@ -58,11 +59,27 @@ type GenerationResponse struct {
 }
 
 // NewOllamaClient crée un nouveau client Ollama
-func NewOllamaClient() *OllamaClient {
+// Si host ou port sont vides, les valeurs par défaut sont utilisées
+func NewOllamaClient(host, port string) *OllamaClient {
+	if host == "" {
+		host = DefaultOllamaHost
+	}
+	if port == "" {
+		port = DefaultOllamaPort
+	}
+	
+	baseURL := fmt.Sprintf("http://%s:%s", host, port)
+	
 	return &OllamaClient{
-		BaseURL: DefaultOllamaURL,
+		BaseURL: baseURL,
 		Client:  &http.Client{},
 	}
+}
+
+// NewDefaultOllamaClient crée un nouveau client Ollama avec les valeurs par défaut
+// Gardé pour compatibilité avec le code existant
+func NewDefaultOllamaClient() *OllamaClient {
+	return NewOllamaClient(DefaultOllamaHost, DefaultOllamaPort)
 }
 
 // GenerateEmbedding génère un embedding pour le texte donné

--- a/internal/service/embedding_service.go
+++ b/internal/service/embedding_service.go
@@ -13,9 +13,12 @@ type EmbeddingService struct {
 }
 
 // NewEmbeddingService creates a new instance of EmbeddingService
-func NewEmbeddingService() *EmbeddingService {
+func NewEmbeddingService(ollamaClient *client.OllamaClient) *EmbeddingService {
+	if ollamaClient == nil {
+		ollamaClient = client.NewDefaultOllamaClient()
+	}
 	return &EmbeddingService{
-		ollamaClient: client.NewOllamaClient(),
+		ollamaClient: ollamaClient,
 	}
 }
 

--- a/internal/service/rag_service.go
+++ b/internal/service/rag_service.go
@@ -18,12 +18,16 @@ type RagService struct {
 }
 
 // NewRagService creates a new instance of RagService
-func NewRagService() *RagService {
+func NewRagService(ollamaClient *client.OllamaClient) *RagService {
+	if ollamaClient == nil {
+		ollamaClient = client.NewDefaultOllamaClient()
+	}
+	
 	return &RagService{
 		documentLoader:   NewDocumentLoader(),
-		embeddingService: NewEmbeddingService(),
+		embeddingService: NewEmbeddingService(ollamaClient),
 		ragRepository:    repository.NewRagRepository(),
-		ollamaClient:     client.NewOllamaClient(),
+		ollamaClient:     ollamaClient,
 	}
 }
 


### PR DESCRIPTION
* Updated README documentation
* The rootCmd sets up persistent flags for --host and --port which will apply to all subcommands. These values are passed to the OllamaClient through the GetOllamaClient function.
* Fixed missing parameters in service instantiations.
* Updated add_docs.go, list_docs.go, remove_doc.go, and update_model.go to use GetOllamaClient()
* Updated function calls to pass the ollamaClient to service constructors
* Removed unused imports in rag.go and run.go
* Verified that the --host and --port command line options are properly recognized and used to configure the Ollama client.