### PR TITLE
Update embedding_service.go

### DIFF
--- a/internal/service/embedding_service.go
+++ b/internal/service/embedding_service.go
@@ -2,6 +2,8 @@ package service
 
 import (
 	"fmt"
+	"os"
+	"os/exec"
 
 	"github.com/dontizi/rlama/internal/client"
 	"github.com/dontizi/rlama/internal/domain"
@@ -24,24 +26,34 @@ func NewEmbeddingService(ollamaClient *client.OllamaClient) *EmbeddingService {
 
 // GenerateEmbeddings generates embeddings for a list of documents
 func (es *EmbeddingService) GenerateEmbeddings(docs []*domain.Document, modelName string) error {
-	// Try to use bge-m3 for embeddings first
-	embeddingModel := "bge-m3"
+	// Try to use snowflake-arctic-embed2 for embeddings first
+	embeddingModel := "snowflake-arctic-embed2"
 	
 	// Process all documents
 	for _, doc := range docs {
-		// Generate embedding with bge-m3 first
+		// Generate embedding with snowflake-arctic-embed2 first
 		embedding, err := es.ollamaClient.GenerateEmbedding(embeddingModel, doc.Content)
 		
-		// If bge-m3 fails, fallback to the specified model
+		// If snowflake-arctic-embed2 fails, try to pull it automatically
 		if err != nil {
 			fmt.Printf("⚠️ Could not use %s for embeddings: %v\n", embeddingModel, err)
-			fmt.Printf("Falling back to %s for embeddings. For better performance, consider:\n", modelName)
-			fmt.Printf("  ollama pull bge-m3\n\n")
 			
-			// Try with the specified model instead
-			embedding, err = es.ollamaClient.GenerateEmbedding(modelName, doc.Content)
-			if err != nil {
-				return fmt.Errorf("error generating embedding for %s: %w", doc.Path, err)
+			// Attempt to pull the embedding model automatically
+			fmt.Printf("Attempting to pull %s automatically...\n", embeddingModel)
+			pullErr := es.pullEmbeddingModel(embeddingModel)
+			
+			if pullErr == nil {
+				// Try again with the pulled model
+				embedding, err = es.ollamaClient.GenerateEmbedding(embeddingModel, doc.Content)
+			}
+			
+			// If pulling failed or embedding still fails, fallback to the specified model
+			if pullErr != nil || err != nil {
+				fmt.Printf("Falling back to %s for embeddings.\n", modelName)
+				embedding, err = es.ollamaClient.GenerateEmbedding(modelName, doc.Content)
+				if err != nil {
+					return fmt.Errorf("error generating embedding for %s: %w", doc.Path, err)
+				}
 			}
 		}
 
@@ -53,50 +65,73 @@ func (es *EmbeddingService) GenerateEmbeddings(docs []*domain.Document, modelNam
 
 // GenerateQueryEmbedding generates an embedding for a query
 func (es *EmbeddingService) GenerateQueryEmbedding(query string, modelName string) ([]float32, error) {
-	// Try to use bge-m3 for embeddings first
-	embeddingModel := "bge-m3"
+	// Try to use snowflake-arctic-embed2 for embeddings first
+	embeddingModel := "snowflake-arctic-embed2"
 	
-	// Generate embedding with bge-m3
+	// Generate embedding with snowflake-arctic-embed2
 	embedding, err := es.ollamaClient.GenerateEmbedding(embeddingModel, query)
 	
-	// If bge-m3 fails, fallback to the specified model
+	// If snowflake-arctic-embed2 fails, try to pull it (but only if not already tried)
 	if err != nil {
 		// We don't need to show the warning again if already shown in GenerateEmbeddings
+		// Attempt to pull the model (this is a no-op if we already tried)
+		pullErr := es.pullEmbeddingModel(embeddingModel)
 		
-		// Try with the specified model instead
-		embedding, err = es.ollamaClient.GenerateEmbedding(modelName, query)
-		if err != nil {
-			return nil, fmt.Errorf("error generating embedding for query: %w", err)
+		if pullErr == nil {
+			// Try again with the pulled model
+			embedding, err = es.ollamaClient.GenerateEmbedding(embeddingModel, query)
+		}
+		
+		// If pulling failed or embedding still fails, fallback to the specified model
+		if pullErr != nil || err != nil {
+			embedding, err = es.ollamaClient.GenerateEmbedding(modelName, query)
+			if err != nil {
+				return nil, fmt.Errorf("error generating embedding for query: %w", err)
+			}
 		}
 	}
 
 	return embedding, nil
 }
 
-// Add a new method for generating embeddings for document chunks
+// GenerateChunkEmbeddings generates embeddings for document chunks
 func (es *EmbeddingService) GenerateChunkEmbeddings(chunks []*domain.DocumentChunk, modelName string) error {
-	// Try to use bge-m3 for embeddings first
-	embeddingModel := "bge-m3"
+	// Try to use snowflake-arctic-embed2 for embeddings first
+	embeddingModel := "snowflake-arctic-embed2"
 	
 	// Process all chunks
 	for i, chunk := range chunks {
 		fmt.Printf("Generating embedding for chunk %d/%d\r", i+1, len(chunks))
 		
-		// Generate embedding with bge-m3 first
+		// Generate embedding with snowflake-arctic-embed2 first
 		embedding, err := es.ollamaClient.GenerateEmbedding(embeddingModel, chunk.Content)
 		
-		// If bge-m3 fails, fallback to the specified model
+		// If snowflake-arctic-embed2 fails and this is the first chunk, try to pull it
 		if err != nil {
-			if i == 0 {  // Only show warning once
+			if i == 0 {
 				fmt.Printf("\n⚠️ Could not use %s for embeddings: %v\n", embeddingModel, err)
-				fmt.Printf("Falling back to %s for embeddings. For better performance, consider:\n", modelName)
-				fmt.Printf("  ollama pull bge-m3\n\n")
+				
+				// Attempt to pull the embedding model automatically
+				fmt.Printf("Attempting to pull %s automatically...\n", embeddingModel)
+				pullErr := es.pullEmbeddingModel(embeddingModel)
+				
+				if pullErr == nil {
+					// Try again with the pulled model
+					embedding, err = es.ollamaClient.GenerateEmbedding(embeddingModel, chunk.Content)
+				}
+				
+				// If pulling failed or embedding still fails, fallback to the specified model
+				if pullErr != nil || err != nil {
+					fmt.Printf("Falling back to %s for embeddings.\n", modelName)
+				}
 			}
 			
-			// Try with the specified model instead
-			embedding, err = es.ollamaClient.GenerateEmbedding(modelName, chunk.Content)
+			// Use the specified model instead if the embedding model failed
 			if err != nil {
-				return fmt.Errorf("error generating embedding for chunk %s: %w", chunk.ID, err)
+				embedding, err = es.ollamaClient.GenerateEmbedding(modelName, chunk.Content)
+				if err != nil {
+					return fmt.Errorf("error generating embedding for chunk %s: %w", chunk.ID, err)
+				}
 			}
 		}
 
@@ -104,4 +139,33 @@ func (es *EmbeddingService) GenerateChunkEmbeddings(chunks []*domain.DocumentChu
 	}
 	fmt.Println() // Add a newline after progress indicator
 	return nil
+}
+
+// Track if we've already tried to pull the model to avoid multiple attempts
+var attemptedModelPull = make(map[string]bool)
+
+// pullEmbeddingModel attempts to pull the embedding model via Ollama
+func (es *EmbeddingService) pullEmbeddingModel(modelName string) error {
+	// Check if we've already tried to pull this model
+	if attemptedModelPull[modelName] {
+		return fmt.Errorf("already attempted to pull model")
+	}
+	
+	// Mark that we've attempted to pull this model
+	attemptedModelPull[modelName] = true
+	
+	// Check if Ollama CLI is available
+	cmd := exec.Command("ollama", "list")
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("ollama command not available: %w", err)
+	}
+	
+	fmt.Printf("Pulling %s model (this may take a while)...\n", modelName)
+	
+	// Run the ollama pull command
+	cmd = exec.Command("ollama", "pull", modelName)
+	cmd.Stdout = os.Stdout // Display output to the user
+	cmd.Stderr = os.Stderr
+	
+	return cmd.Run()
 } 


### PR DESCRIPTION
This pull request includes significant updates to the `EmbeddingService` in the `internal/service/embedding_service.go` file. The changes focus on improving the embedding generation process by switching to a new default model and adding functionality to automatically pull the model if it is not available.

Updates to embedding model and auto-pull functionality:

* Changed the default embedding model from `bge-m3` to `snowflake-arctic-embed2` in `GenerateEmbeddings`, `GenerateQueryEmbedding`, and `GenerateChunkEmbeddings` methods. [[1]](diffhunk://#diff-488da8aa631f97aae016bfff393f21c3f754b292ec30636718f041c8742dc4b8L27-R58) [[2]](diffhunk://#diff-488da8aa631f97aae016bfff393f21c3f754b292ec30636718f041c8742dc4b8L56-R171)
* Added logic to automatically pull the embedding model if it is not available, including a new method `pullEmbeddingModel` and a mechanism to track if a pull attempt has already been made.
* Updated error handling to attempt pulling the model and retrying the embedding generation before falling back to the specified model. [[1]](diffhunk://#diff-488da8aa631f97aae016bfff393f21c3f754b292ec30636718f041c8742dc4b8L27-R58) [[2]](diffhunk://#diff-488da8aa631f97aae016bfff393f21c3f754b292ec30636718f041c8742dc4b8L56-R171)

Additional changes:

* Imported `os` and `os/exec` packages to support the new model pulling functionality.