### PR TITLE
Directory watcher for rag pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,9 @@ RLAMA is a powerful AI-driven question-answering tool for your documents, seamle
 - [Installation](#installation)
 - [Available Commands](#available-commands)
   - [rag - Create a RAG system](#rag---create-a-rag-system)
+  - [watch - Set up directory watching for a RAG system](#watch---set-up-directory-watching-for-a-rag-system)
+  - [watch-off - Disable directory watching for a RAG system](#watch-off---disable-directory-watching-for-a-rag-system)
+  - [check-watched - Check a RAG's watched directory for new files](#check-watched---check-a-rag's-watched-directory-for-new-files)
   - [run - Use a RAG system](#run---use-a-rag-system)
   - [api - Start API server](#api---start-api-server)
   - [list - List RAG systems](#list---list-rag-systems)
@@ -200,6 +203,66 @@ rlama rag [model] [rag-name] [folder-path]
 
 ```bash
 rlama rag llama3 documentation ./docs
+```
+
+### watch - Set up directory watching for a RAG system
+
+Configure a RAG system to automatically watch a directory for new files and add them to the RAG.
+
+```bash
+rlama watch [rag-name] [directory-path] [interval]
+```
+
+**Parameters:**
+- `rag-name`: Name of the RAG system to watch.
+- `directory-path`: Path to the directory to watch for new files.
+- `interval`: Time in minutes to check for new files (use 0 to check only when the RAG is used).
+
+**Example:**
+
+```bash
+# Set up directory watching to check every 60 minutes
+rlama watch my-docs ./watched-folder 60
+
+# Set up directory watching to only check when the RAG is used
+rlama watch my-docs ./watched-folder 0
+
+# Customize what files to watch
+rlama watch my-docs ./watched-folder 30 --exclude-dir=node_modules,tmp --process-ext=.md,.txt
+```
+
+### watch-off - Disable directory watching for a RAG system
+
+Disable automatic directory watching for a RAG system.
+
+```bash
+rlama watch-off [rag-name]
+```
+
+**Parameters:**
+- `rag-name`: Name of the RAG system to disable watching.
+
+**Example:**
+
+```bash
+rlama watch-off my-docs
+```
+
+### check-watched - Check a RAG's watched directory for new files
+
+Manually check a RAG's watched directory for new files and add them to the RAG.
+
+```bash
+rlama check-watched [rag-name]
+```
+
+**Parameters:**
+- `rag-name`: Name of the RAG system to check.
+
+**Example:**
+
+```bash
+rlama check-watched my-docs
 ```
 
 ### run - Use a RAG system

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -4,10 +4,12 @@ import (
 	"fmt"
 	"os"
 	"runtime"
+	"time"
 
 	"github.com/spf13/cobra"
 	
 	"github.com/dontizi/rlama/internal/client"
+	"github.com/dontizi/rlama/internal/service"
 )
 
 const (
@@ -79,4 +81,22 @@ func init() {
 			cmd.Help()
 		}
 	}
+	
+	// Start the watcher daemon
+	go startFileWatcherDaemon()
+}
+
+// Add this function to start the watcher daemon
+func startFileWatcherDaemon() {
+	// Wait a bit for application initialization
+	time.Sleep(2 * time.Second)
+	
+	// Create the services
+	ollamaClient := GetOllamaClient()
+	ragService := service.NewRagService(ollamaClient)
+	fileWatcher := service.NewFileWatcher(ragService)
+	
+	// Start the daemon with a 1-minute check interval for its internal operations
+	// Actual RAG check intervals are controlled by each RAG's configuration
+	fileWatcher.StartWatcherDaemon(1 * time.Minute)
 } 

--- a/cmd/watch.go
+++ b/cmd/watch.go
@@ -1,0 +1,162 @@
+package cmd
+
+import (
+	"fmt"
+	"strconv"
+
+	"github.com/spf13/cobra"
+	"github.com/dontizi/rlama/internal/service"
+)
+
+var (
+	watchExcludeDirs  []string
+	watchExcludeExts  []string
+	watchProcessExts  []string
+	watchChunkSize    int
+	watchChunkOverlap int
+)
+
+var watchCmd = &cobra.Command{
+	Use:   "watch [rag-name] [directory-path] [interval]",
+	Short: "Set up directory watching for a RAG system",
+	Long: `Configure a RAG system to automatically watch a directory for new files and add them to the RAG.
+The interval is specified in minutes. Use 0 to only check when the RAG is used.
+
+Example: rlama watch my-docs ./documents 60
+This will check the ./documents directory every 60 minutes for new files.
+
+Use rlama watch-off [rag-name] to disable watching.`,
+	Args: cobra.RangeArgs(2, 3),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		ragName := args[0]
+		dirPath := args[1]
+		
+		// Default interval is 0 (only check when RAG is used)
+		interval := 0
+		
+		// If an interval is provided, parse it
+		if len(args) > 2 {
+			var err error
+			interval, err = strconv.Atoi(args[2])
+			if err != nil {
+				return fmt.Errorf("invalid interval: %s", args[2])
+			}
+			
+			if interval < 0 {
+				return fmt.Errorf("interval must be non-negative")
+			}
+		}
+		
+		// Get Ollama client from root command
+		ollamaClient := GetOllamaClient()
+		
+		// Create RAG service
+		ragService := service.NewRagService(ollamaClient)
+		
+		// Set up loader options based on flags
+		loaderOptions := service.DocumentLoaderOptions{
+			ExcludeDirs:  watchExcludeDirs,
+			ExcludeExts:  watchExcludeExts,
+			ProcessExts:  watchProcessExts,
+			ChunkSize:    watchChunkSize,
+			ChunkOverlap: watchChunkOverlap,
+		}
+		
+		// Set up directory watching
+		err := ragService.SetupDirectoryWatching(ragName, dirPath, interval, loaderOptions)
+		if err != nil {
+			return err
+		}
+		
+		// Provide feedback based on the interval
+		if interval == 0 {
+			fmt.Printf("Directory watching set up for RAG '%s'. Directory '%s' will be checked each time the RAG is used.\n", 
+				ragName, dirPath)
+		} else {
+			fmt.Printf("Directory watching set up for RAG '%s'. Directory '%s' will be checked every %d minutes.\n", 
+				ragName, dirPath, interval)
+		}
+		
+		// Perform an initial check
+		docsAdded, err := ragService.CheckWatchedDirectory(ragName)
+		if err != nil {
+			return fmt.Errorf("error during initial directory check: %w", err)
+		}
+		
+		if docsAdded > 0 {
+			fmt.Printf("Added %d new documents from '%s'.\n", docsAdded, dirPath)
+		} else {
+			fmt.Printf("No new documents found in '%s'.\n", dirPath)
+		}
+		
+		return nil
+	},
+}
+
+var watchOffCmd = &cobra.Command{
+	Use:   "watch-off [rag-name]",
+	Short: "Disable directory watching for a RAG system",
+	Long:  `Disable automatic directory watching for a RAG system.`,
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		ragName := args[0]
+		
+		// Get Ollama client from root command
+		ollamaClient := GetOllamaClient()
+		
+		// Create RAG service
+		ragService := service.NewRagService(ollamaClient)
+		
+		// Disable directory watching
+		err := ragService.DisableDirectoryWatching(ragName)
+		if err != nil {
+			return err
+		}
+		
+		fmt.Printf("Directory watching disabled for RAG '%s'.\n", ragName)
+		return nil
+	},
+}
+
+var checkWatchedCmd = &cobra.Command{
+	Use:   "check-watched [rag-name]",
+	Short: "Check a RAG's watched directory for new files",
+	Long:  `Manually check a RAG's watched directory for new files and add them to the RAG.`,
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		ragName := args[0]
+		
+		// Get Ollama client from root command
+		ollamaClient := GetOllamaClient()
+		
+		// Create RAG service
+		ragService := service.NewRagService(ollamaClient)
+		
+		// Check the watched directory
+		docsAdded, err := ragService.CheckWatchedDirectory(ragName)
+		if err != nil {
+			return err
+		}
+		
+		if docsAdded > 0 {
+			fmt.Printf("Added %d new documents to RAG '%s'.\n", docsAdded, ragName)
+		} else {
+			fmt.Printf("No new documents found for RAG '%s'.\n", ragName)
+		}
+		
+		return nil
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(watchCmd)
+	rootCmd.AddCommand(watchOffCmd)
+	rootCmd.AddCommand(checkWatchedCmd)
+	
+	// Add exclusion and processing flags
+	watchCmd.Flags().StringSliceVar(&watchExcludeDirs, "exclude-dir", nil, "Directories to exclude (comma-separated)")
+	watchCmd.Flags().StringSliceVar(&watchExcludeExts, "exclude-ext", nil, "File extensions to exclude (comma-separated)")
+	watchCmd.Flags().StringSliceVar(&watchProcessExts, "process-ext", nil, "Only process these file extensions (comma-separated)")
+	watchCmd.Flags().IntVar(&watchChunkSize, "chunk-size", 1000, "Character count per chunk (default: 1000)")
+	watchCmd.Flags().IntVar(&watchChunkOverlap, "chunk-overlap", 200, "Overlap between chunks in characters (default: 200)")
+} 

--- a/internal/domain/rag.go
+++ b/internal/domain/rag.go
@@ -8,14 +8,29 @@ import (
 
 // RagSystem represents a complete RAG system
 type RagSystem struct {
-	Name        string        `json:"name"`
-	ModelName   string        `json:"model_name"`
-	CreatedAt   time.Time     `json:"created_at"`
-	UpdatedAt   time.Time     `json:"updated_at"`
-	Description string        `json:"description"`
-	HybridStore *vector.EnhancedHybridStore // Use the hybrid store
-	Documents   []*Document     `json:"documents"`
-	Chunks      []*DocumentChunk `json:"chunks"`
+	Name            string               `json:"name"`
+	ModelName       string               `json:"model_name"`
+	CreatedAt       time.Time            `json:"created_at"`
+	UpdatedAt       time.Time            `json:"updated_at"`
+	Description     string               `json:"description"`
+	HybridStore     *vector.EnhancedHybridStore // Use the hybrid store
+	Documents       []*Document          `json:"documents"`
+	Chunks          []*DocumentChunk     `json:"chunks"`
+	// Add directory watching settings
+	WatchedDir      string               `json:"watched_dir,omitempty"`
+	WatchInterval   int                  `json:"watch_interval,omitempty"` // In minutes, 0 means only check on use
+	LastWatchedAt   time.Time            `json:"last_watched_at,omitempty"`
+	WatchEnabled    bool                 `json:"watch_enabled"`
+	WatchOptions    DocumentWatchOptions `json:"watch_options,omitempty"`
+}
+
+// DocumentWatchOptions stores settings for directory watching
+type DocumentWatchOptions struct {
+	ExcludeDirs   []string `json:"exclude_dirs,omitempty"`
+	ExcludeExts   []string `json:"exclude_exts,omitempty"`
+	ProcessExts   []string `json:"process_exts,omitempty"`
+	ChunkSize     int      `json:"chunk_size,omitempty"`
+	ChunkOverlap  int      `json:"chunk_overlap,omitempty"`
 }
 
 // NewRagSystem creates a new instance of RagSystem

--- a/internal/service/file_watcher.go
+++ b/internal/service/file_watcher.go
@@ -1,0 +1,203 @@
+package service
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/dontizi/rlama/internal/domain"
+)
+
+// FileWatcher is responsible for watching directories for file changes
+type FileWatcher struct {
+	ragService RagService
+}
+
+// NewFileWatcher creates a new file watcher service
+func NewFileWatcher(ragService RagService) *FileWatcher {
+	return &FileWatcher{
+		ragService: ragService,
+	}
+}
+
+// CheckAndUpdateRag checks for new files in the watched directory and updates the RAG
+func (fw *FileWatcher) CheckAndUpdateRag(rag *domain.RagSystem) (int, error) {
+	if !rag.WatchEnabled || rag.WatchedDir == "" {
+		return 0, nil // Watching not enabled
+	}
+
+	// Check if the directory exists
+	dirInfo, err := os.Stat(rag.WatchedDir)
+	if os.IsNotExist(err) {
+		return 0, fmt.Errorf("watched directory '%s' does not exist", rag.WatchedDir)
+	} else if err != nil {
+		return 0, fmt.Errorf("error accessing watched directory: %w", err)
+	}
+
+	if !dirInfo.IsDir() {
+		return 0, fmt.Errorf("'%s' is not a directory", rag.WatchedDir)
+	}
+
+	// Get the last modified time of the directory
+	lastModified := getLastModifiedTime(rag.WatchedDir)
+	
+	// If the directory hasn't been modified since last check, no need to proceed
+	if !lastModified.After(rag.LastWatchedAt) && !rag.LastWatchedAt.IsZero() {
+		return 0, nil
+	}
+
+	// Convert watch options to document loader options
+	loaderOptions := DocumentLoaderOptions{
+		ExcludeDirs:  rag.WatchOptions.ExcludeDirs,
+		ExcludeExts:  rag.WatchOptions.ExcludeExts,
+		ProcessExts:  rag.WatchOptions.ProcessExts,
+		ChunkSize:    rag.WatchOptions.ChunkSize,
+		ChunkOverlap: rag.WatchOptions.ChunkOverlap,
+	}
+
+	// Get existing document paths to avoid re-processing
+	existingPaths := make(map[string]bool)
+	for _, doc := range rag.Documents {
+		existingPaths[doc.Path] = true
+	}
+
+	// Create a document loader
+	docLoader := NewDocumentLoader()
+	
+	// Load all documents from the directory
+	allDocs, err := docLoader.LoadDocumentsFromFolderWithOptions(rag.WatchedDir, loaderOptions)
+	if err != nil {
+		return 0, fmt.Errorf("error loading documents from watched directory: %w", err)
+	}
+
+	// Filter out existing documents
+	var newDocs []*domain.Document
+	for _, doc := range allDocs {
+		if !existingPaths[doc.Path] {
+			newDocs = append(newDocs, doc)
+		}
+	}
+
+	if len(newDocs) == 0 {
+		// Update last watched time even if no new documents
+		rag.LastWatchedAt = time.Now()
+		err = fw.ragService.UpdateRag(rag)
+		return 0, err
+	}
+
+	// Create chunker service with options from the RAG
+	chunkerService := NewChunkerService(ChunkingConfig{
+		ChunkSize:    loaderOptions.ChunkSize,
+		ChunkOverlap: loaderOptions.ChunkOverlap,
+	})
+
+	// Process each new document - chunk and prepare for embeddings
+	var allChunks []*domain.DocumentChunk
+	for _, doc := range newDocs {
+		// Chunk the document
+		chunks := chunkerService.ChunkDocument(doc)
+		
+		// Update total chunks in metadata
+		for i, chunk := range chunks {
+			chunk.ChunkNumber = i
+			chunk.TotalChunks = len(chunks)
+		}
+		
+		allChunks = append(allChunks, chunks...)
+	}
+
+	// Generate embeddings for all chunks
+	embeddingService := NewEmbeddingService(fw.ragService.GetOllamaClient())
+	err = embeddingService.GenerateChunkEmbeddings(allChunks, rag.ModelName)
+	if err != nil {
+		return 0, fmt.Errorf("error generating embeddings for new documents: %w", err)
+	}
+
+	// Add documents and chunks to the RAG
+	for _, doc := range newDocs {
+		rag.AddDocument(doc)
+	}
+	
+	for _, chunk := range allChunks {
+		rag.AddChunk(chunk)
+	}
+
+	// Update last watched time
+	rag.LastWatchedAt = time.Now()
+	
+	// Save the updated RAG
+	err = fw.ragService.UpdateRag(rag)
+	if err != nil {
+		return 0, fmt.Errorf("error saving updated RAG: %w", err)
+	}
+
+	return len(newDocs), nil
+}
+
+// getLastModifiedTime gets the latest modification time in a directory
+func getLastModifiedTime(dirPath string) time.Time {
+	var lastModTime time.Time
+
+	// Walk through the directory and find the latest modification time
+	filepath.Walk(dirPath, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return nil // Skip errors
+		}
+		
+		if info.ModTime().After(lastModTime) {
+			lastModTime = info.ModTime()
+		}
+		
+		return nil
+	})
+
+	return lastModTime
+}
+
+// StartWatcherDaemon starts a background daemon to watch directories
+// for all RAGs that have watching enabled with intervals
+func (fw *FileWatcher) StartWatcherDaemon(interval time.Duration) {
+	go func() {
+		ticker := time.NewTicker(interval)
+		defer ticker.Stop()
+
+		for {
+			<-ticker.C
+			fw.checkAllRags()
+		}
+	}()
+}
+
+// checkAllRags checks all RAGs with watching enabled
+func (fw *FileWatcher) checkAllRags() {
+	// Get all RAGs
+	rags, err := fw.ragService.ListAllRags()
+	if err != nil {
+		fmt.Printf("Error listing RAGs for file watching: %v\n", err)
+		return
+	}
+
+	now := time.Now()
+	
+	for _, ragName := range rags {
+		rag, err := fw.ragService.LoadRag(ragName)
+		if err != nil {
+			fmt.Printf("Error loading RAG %s: %v\n", ragName, err)
+			continue
+		}
+
+		// Check if watching is enabled and if interval has passed
+		if rag.WatchEnabled && rag.WatchInterval > 0 {
+			intervalDuration := time.Duration(rag.WatchInterval) * time.Minute
+			if now.Sub(rag.LastWatchedAt) >= intervalDuration {
+				docsAdded, err := fw.CheckAndUpdateRag(rag)
+				if err != nil {
+					fmt.Printf("Error checking for updates in RAG %s: %v\n", ragName, err)
+				} else if docsAdded > 0 {
+					fmt.Printf("Added %d new documents to RAG %s from watched directory\n", docsAdded, ragName)
+				}
+			}
+		}
+	}
+} 


### PR DESCRIPTION
This pull request introduces a new directory watching feature for RAG systems in the `rlama` project. The key changes include updates to the `README.md` file to document new commands, modifications to the command files to handle directory watching, and the addition of new services and methods to support the feature.

### Documentation Updates:
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R27-R29): Added documentation for new commands `watch`, `watch-off`, and `check-watched`. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R27-R29) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R208-R267)

### Command Additions and Modifications:
* [`cmd/root.go`](diffhunk://#diff-ab967ab1a2f3a1b769106eeb7bfe892ef0e81d1d27811fa15be08e6749feee1fR7-R12): Imported the new `service` package and added a function to start the watcher daemon. [[1]](diffhunk://#diff-ab967ab1a2f3a1b769106eeb7bfe892ef0e81d1d27811fa15be08e6749feee1fR7-R12) [[2]](diffhunk://#diff-ab967ab1a2f3a1b769106eeb7bfe892ef0e81d1d27811fa15be08e6749feee1fR84-R101)
* [`cmd/run.go`](diffhunk://#diff-8146f8148ccbf6711d65f532f6ab9a7c8dfbdc3960c7ffc974f17d6d224dd349R11): Added a call to `checkWatchedDirectory` to check for new files before querying the RAG system. [[1]](diffhunk://#diff-8146f8148ccbf6711d65f532f6ab9a7c8dfbdc3960c7ffc974f17d6d224dd349R11) [[2]](diffhunk://#diff-8146f8148ccbf6711d65f532f6ab9a7c8dfbdc3960c7ffc974f17d6d224dd349R61-R62) [[3]](diffhunk://#diff-8146f8148ccbf6711d65f532f6ab9a7c8dfbdc3960c7ffc974f17d6d224dd349R84-R96)
* [`cmd/watch.go`](diffhunk://#diff-b1d36367bc59ae1783324a4e3f2f6d15d421aa8f8a966109b04e3d77058184b8R1-R162): Created new commands `watch`, `watch-off`, and `check-watched` to manage directory watching for RAG systems.

### Service and Domain Changes:
* [`internal/domain/rag.go`](diffhunk://#diff-298fd7511dab8e5e5f020a531394be216f4371e4ebe3624011f1f27e7790509eR19-R33): Added fields to `RagSystem` to store directory watching settings and created a new `DocumentWatchOptions` struct.
* [`internal/service/file_watcher.go`](diffhunk://#diff-7330841e716e4324bf9ca9ab22eac1aa66e7c7b6249161706d7ce5b1478747fdR1-R203): Implemented the `FileWatcher` service to handle directory watching, checking for new files, and updating RAG systems.
* [`internal/service/rag_service.go`](diffhunk://#diff-cf1dacf22586e45564587ed181f75a38110a790c94262a247dc3c46d03ed5e1eR5-R7): Added methods to `RagService` to set up, disable, and check directory watching for RAG systems. [[1]](diffhunk://#diff-cf1dacf22586e45564587ed181f75a38110a790c94262a247dc3c46d03ed5e1eR5-R7) [[2]](diffhunk://#diff-cf1dacf22586e45564587ed181f75a38110a790c94262a247dc3c46d03ed5e1eR23-R28) [[3]](diffhunk://#diff-cf1dacf22586e45564587ed181f75a38110a790c94262a247dc3c46d03ed5e1eR315-R396)