### PR TITLE
Add Hugging Face GGUF Model Integration via Ollama

### DIFF
--- a/README.md
+++ b/README.md
@@ -731,3 +731,41 @@ rlama update-model --help
 All commands support the global `--host` and `--port` flags for custom Ollama connections.
 
 The precedence order is: command-line flags > environment variable > default values.
+
+## Hugging Face Integration
+
+RLAMA now supports using GGUF models directly from Hugging Face through Ollama's native integration:
+
+### Browsing Hugging Face Models
+
+```bash
+# Search for GGUF models on Hugging Face
+rlama hf-browse "llama 3"
+
+# Open browser with search results
+rlama hf-browse mistral --open
+```
+
+### Testing a Model
+
+Before creating a RAG, you can test a Hugging Face model directly:
+
+```bash
+# Try a model in chat mode
+rlama run-hf bartowski/Llama-3.2-1B-Instruct-GGUF
+
+# Specify quantization
+rlama run-hf mlabonne/Meta-Llama-3.1-8B-Instruct-abliterated-GGUF --quant Q5_K_M
+```
+
+### Creating a RAG with Hugging Face Models
+
+Use Hugging Face models when creating RAG systems:
+
+```bash
+# Create a RAG with a Hugging Face model
+rlama rag hf.co/bartowski/Llama-3.2-1B-Instruct-GGUF my-rag ./docs
+
+# Use specific quantization
+rlama rag hf.co/mlabonne/Meta-Llama-3.1-8B-Instruct-abliterated-GGUF:Q5_K_M my-rag ./docs
+```

--- a/cmd/hf_browse.go
+++ b/cmd/hf_browse.go
@@ -1,0 +1,79 @@
+package cmd
+
+import (
+	"fmt"
+	"os/exec"
+	"runtime"
+	"strings"
+
+	"github.com/spf13/cobra"
+)
+
+var (
+	browseQuantization string
+	browseLimit        int
+	browseOpen         bool
+)
+
+var hfBrowseCmd = &cobra.Command{
+	Use:   "hf-browse [search-term]",
+	Short: "Browse GGUF models on Hugging Face",
+	Long: `Search and browse GGUF models available on Hugging Face.
+Optionally open the browser to view the model details.
+
+Examples:
+  rlama hf-browse llama3       # Search for Llama 3 models
+  rlama hf-browse mistral --open # Search and open browser
+  rlama hf-browse "open instruct" --limit 5  # Limit results`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		searchTerm := ""
+		if len(args) > 0 {
+			searchTerm = strings.Join(args, " ")
+		}
+
+		// Build the search URL
+		searchURL := "https://huggingface.co/models?search=gguf"
+		if searchTerm != "" {
+			searchURL += "+" + strings.ReplaceAll(searchTerm, " ", "+")
+		}
+
+		if browseOpen {
+			var err error
+			switch runtime.GOOS {
+			case "linux":
+				err = exec.Command("xdg-open", searchURL).Start()
+			case "windows":
+				err = exec.Command("rundll32", "url.dll,FileProtocolHandler", searchURL).Start()
+			case "darwin":
+				err = exec.Command("open", searchURL).Start()
+			default:
+				err = fmt.Errorf("unsupported platform")
+			}
+			if err != nil {
+				return fmt.Errorf("error opening browser: %w", err)
+			}
+			fmt.Printf("Opened browser to search for GGUF models: %s\n", searchURL)
+		}
+
+		fmt.Println("To use a Hugging Face model with RLAMA, use the format:")
+		fmt.Println("  rlama rag hf.co/username/repository my-rag ./docs")
+		
+		if browseQuantization != "" {
+			fmt.Println("\nSpecify quantization:")
+			fmt.Println("  rlama rag hf.co/username/repository:" + browseQuantization + " my-rag ./docs")
+		}
+		
+		fmt.Println("\nOr try out a model directly with:")
+		fmt.Println("  rlama run-hf username/repository")
+		
+		return nil
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(hfBrowseCmd)
+	
+	hfBrowseCmd.Flags().StringVar(&browseQuantization, "quant", "", "Specify quantization type (e.g., Q4_K_M, Q5_K_M)")
+	hfBrowseCmd.Flags().IntVar(&browseLimit, "limit", 10, "Limit number of results")
+	hfBrowseCmd.Flags().BoolVar(&browseOpen, "open", false, "Open browser with search results")
+} 

--- a/cmd/rag.go
+++ b/cmd/rag.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/spf13/cobra"
 	"github.com/dontizi/rlama/internal/service"
+	"github.com/dontizi/rlama/internal/client"
 )
 
 var (
@@ -28,7 +29,14 @@ Supported formats include: .txt, .md, .html, .json, .csv, and various source cod
 You can exclude directories or file types:
   rlama rag llama3 myproject ./code --excludedir=node_modules,dist,.git
   rlama rag llama3 mydocs ./docs --excludeext=.log,.tmp
-  rlama rag llama3 specific ./mixed --processext=.md,.py,.js`,
+  rlama rag llama3 specific ./mixed --processext=.md,.py,.js
+
+Hugging Face Models:
+  You can use Hugging Face GGUF models with the format:
+  rlama rag hf.co/username/repository my-rag ./docs
+  
+  Specify quantization with:
+  rlama rag hf.co/username/repository:Q4_K_M my-rag ./docs`,
 	Args: cobra.ExactArgs(3),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		modelName := args[0]
@@ -37,8 +45,25 @@ You can exclude directories or file types:
 
 		// Get Ollama client with configured host and port
 		ollamaClient := GetOllamaClient()
-		if err := ollamaClient.CheckOllamaAndModel(modelName); err != nil {
-			return err
+		
+		// Check if this is a Hugging Face model
+		isHfModel := client.IsHuggingFaceModel(modelName)
+		
+		if isHfModel {
+			// Extract quantization if specified
+			hfModelName := client.GetHuggingFaceModelName(modelName)
+			quantization := client.GetQuantizationFromModelRef(modelName)
+			
+			// Pull the model from Hugging Face
+			fmt.Printf("Pulling Hugging Face model %s...\n", hfModelName)
+			if err := ollamaClient.PullHuggingFaceModel(hfModelName, quantization); err != nil {
+				return fmt.Errorf("error pulling Hugging Face model: %w", err)
+			}
+		} else {
+			// Regular Ollama model check
+			if err := ollamaClient.CheckOllamaAndModel(modelName); err != nil {
+				return err
+			}
 		}
 
 		// Display a message to indicate that the process has started

--- a/cmd/run_hf.go
+++ b/cmd/run_hf.go
@@ -1,0 +1,48 @@
+package cmd
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/spf13/cobra"
+)
+
+var (
+	runHfQuantization string
+)
+
+var runHfCmd = &cobra.Command{
+	Use:   "run-hf [huggingface-model]",
+	Short: "Run a Hugging Face GGUF model with Ollama",
+	Long: `Run a Hugging Face GGUF model directly using Ollama.
+This is convenient for testing models before creating a RAG system with them.
+
+Examples:
+  rlama run-hf bartowski/Llama-3.2-1B-Instruct-GGUF
+  rlama run-hf mlabonne/Meta-Llama-3.1-8B-Instruct-abliterated-GGUF --quant Q5_K_M`,
+	Args: cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		modelPath := args[0]
+		
+		// Prepare the model reference
+		if !strings.Contains(modelPath, "/") {
+			return fmt.Errorf("invalid model format. Use 'username/repository' format")
+		}
+		
+		// Get the Ollama client
+		ollamaClient := GetOllamaClient()
+		
+		fmt.Printf("Running Hugging Face model: %s\n", modelPath)
+		if runHfQuantization != "" {
+			fmt.Printf("Using quantization: %s\n", runHfQuantization)
+		}
+		
+		return ollamaClient.RunHuggingFaceModel(modelPath, runHfQuantization)
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(runHfCmd)
+	
+	runHfCmd.Flags().StringVar(&runHfQuantization, "quant", "", "Quantization to use (e.g., Q4_K_M, Q5_K_M)")
+} 


### PR DESCRIPTION
This pull request introduces significant new functionality for integrating Hugging Face GGUF models with RLAMA, including commands for browsing, running, and creating RAG systems with these models. Key changes include updates to documentation, new command implementations, and modifications to existing commands to support Hugging Face models.

### Hugging Face Integration

* **Documentation Update:**
  - Added a new section in `README.md` detailing how to browse, test, and create RAGs with Hugging Face GGUF models using RLAMA.

* **New Commands:**
  - Implemented `hf-browse` command in `cmd/hf_browse.go` to search for GGUF models on Hugging Face and optionally open the browser with search results.
  - Added `run-hf` command in `cmd/run_hf.go` to run Hugging Face GGUF models directly using Ollama for testing purposes.

* **Command Enhancements:**
  - Updated the `rag` command in `cmd/rag.go` to support Hugging Face models, including handling model references and quantization. [[1]](diffhunk://#diff-444c6927b18b49818b19caa855bc34f17b6940e61e56e8bc3de5a8a38a4c7979L31-R39) [[2]](diffhunk://#diff-444c6927b18b49818b19caa855bc34f17b6940e61e56e8bc3de5a8a38a4c7979R48-R67)

### Client Modifications

* **Ollama Client Enhancements:**
  - Added methods in `internal/client/ollama_client.go` to run and pull Hugging Face models, and to check if a model is a Hugging Face reference.
  - Included necessary imports for executing commands in `internal/client/ollama_client.go`.