### PR TITLE
fixed Ollama Client

### DIFF
--- a/internal/service/rag_service.go
+++ b/internal/service/rag_service.go
@@ -200,7 +200,8 @@ func (rs *RagServiceImpl) Query(rag *domain.RagSystem, query string, contextSize
 	}
 	
 	// Build the prompt with better formatting and instructions for citing sources
-	prompt := fmt.Sprintf(`You are a helpful AI assistant. Use the information below to answer the question.
+	systemMessage := "You are a helpful assistant that provides accurate information based on the documents you've been given. Answer the question based on the context provided. If you don't know the answer based on the context, say that you don't know rather than making up an answer. Important: Always respond in the same language as the user's query."
+	prompt := fmt.Sprintf(`%s
 
 %s
 
@@ -208,7 +209,7 @@ Question: %s
 
 Answer based on the provided information. If the information doesn't contain the answer, say so clearly.
 Include references to the source documents in your answer using the format (Source: document name).`, 
-	context.String(), query)
+	systemMessage, context.String(), query)
 	
 	// Show search results to the user
 	fmt.Println("\nSearching documents...\n")


### PR DESCRIPTION
This pull request includes changes to the `internal/client/ollama_client.go` and `internal/service/rag_service.go` files, focusing on improving the handling of environment variables, command flags, and prompt formatting. The most important changes include adding protocol handling for the `OLLAMA_HOST` environment variable and command flags, and enhancing the prompt message for better clarity and instruction.

**Improvements to environment variable and command flag handling:**

* [`internal/client/ollama_client.go`](diffhunk://#diff-2a02fa385cdd833fd3a67ea16ddeacf6bf72e4e5dbeae7e152e7b3ef87a3965fL72-R92): Added protocol handling for the `OLLAMA_HOST` environment variable, allowing it to include `http://` or `https://` prefixes. This ensures that the protocol is correctly extracted and used in the base URL. [[1]](diffhunk://#diff-2a02fa385cdd833fd3a67ea16ddeacf6bf72e4e5dbeae7e152e7b3ef87a3965fL72-R92) [[2]](diffhunk://#diff-2a02fa385cdd833fd3a67ea16ddeacf6bf72e4e5dbeae7e152e7b3ef87a3965fR101-R120)
* [`internal/client/ollama_client.go`](diffhunk://#diff-2a02fa385cdd833fd3a67ea16ddeacf6bf72e4e5dbeae7e152e7b3ef87a3965fR101-R120): Modified the command flag handling to also support protocols in the host string, ensuring consistency with the environment variable handling.

**Enhancements to prompt formatting:**

* [`internal/service/rag_service.go`](diffhunk://#diff-cf1dacf22586e45564587ed181f75a38110a790c94262a247dc3c46d03ed5e1eL203-R212): Updated the prompt message to provide clearer instructions for citing sources and responding accurately based on the context. This includes a new system message emphasizing the importance of accurate information and responding in the same language as the user's query.