### PR TITLE
fixed update and uninstall with rlama in windows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ dist/
 .DS_Store
 bin/
 hook-executed.log
+rlama.exe
+*.exe

--- a/cmd/uninstall.go
+++ b/cmd/uninstall.go
@@ -90,9 +90,10 @@ var uninstallCmd = &cobra.Command{
 				// On Windows, try to remove directly
 				err = os.Remove(executablePath)
 				if err != nil {
-					// If direct removal fails, try with elevated privileges
+					// If direct removal fails, try with elevated privileges using full PowerShell path
 					fmt.Println("Need elevated privileges to remove the executable")
-					err = execCommand("powershell", "-Command", fmt.Sprintf("Start-Process -Verb RunAs -FilePath 'cmd.exe' -ArgumentList '/c del \"%s\"'", executablePath))
+					powershellPath := filepath.Join(os.Getenv("SystemRoot"), "System32", "WindowsPowerShell", "v1.0", "powershell.exe")
+					err = execCommand(powershellPath, "-Command", fmt.Sprintf("Start-Process -Verb RunAs -FilePath 'cmd.exe' -ArgumentList '/c del \"%s\"'", executablePath))
 				}
 			} else if isRoot() {
 				// If we're already root on Unix systems

--- a/install.ps1
+++ b/install.ps1
@@ -1,8 +1,11 @@
 # Windows installation script for RLAMA
 Write-Host "
-█▀█ █   ▄▀█ █▀▄▀█ ▄▀█
-█▀▄ █▄▄ █▀█ █░▀░█ █▀█
-
+ ____  _       _    __  __    _    
+|  _ \| |     / \  |  \/  |  / \   
+| |_) | |    / _ \ | |\/| | / _ \  
+|  _ <| |___/ ___ \| |  | |/ ___ \ 
+|_| \_\_____/_/   \_\_|  |_/_/   \_\
+                                  
 Retrieval-Augmented Language Model Adapter for Windows
 "
 


### PR DESCRIPTION
This pull request includes several updates to improve the Windows update and uninstall processes for the RLAMA application. The most important changes involve adjustments to the PowerShell path for elevated privileges, a new approach for handling Windows updates, and enhancements to the update script.

### Improvements to Windows update and uninstall processes:

* [`cmd/uninstall.go`](diffhunk://#diff-c5c57f19bbf680c50120a5a7cb3cdb06163fd9b206226d44b319fb5cd81da49cL93-R96): Updated the uninstall command to use the full PowerShell path when elevated privileges are required for removing the executable.
* [`cmd/update.go`](diffhunk://#diff-711a4354cb9e88f469f82742ba63b8b9abc7a40b99dd9c090f78cda73377774aL141-R141): Replaced the `windowsReplaceBinary` function with `doWindowsUpdate`, which includes creating a temporary batch script in a known location and providing clearer instructions for completing the update manually if necessary. [[1]](diffhunk://#diff-711a4354cb9e88f469f82742ba63b8b9abc7a40b99dd9c090f78cda73377774aL141-R141) [[2]](diffhunk://#diff-711a4354cb9e88f469f82742ba63b8b9abc7a40b99dd9c090f78cda73377774aL155-L163)
* [`cmd/update.go`](diffhunk://#diff-711a4354cb9e88f469f82742ba63b8b9abc7a40b99dd9c090f78cda73377774aL198-R226): Enhanced the update script to include a pause instead of a timeout, ensuring users have time to read the instructions.
* [`cmd/update.go`](diffhunk://#diff-711a4354cb9e88f469f82742ba63b8b9abc7a40b99dd9c090f78cda73377774aL184-R196): Modified the batch script to provide more explicit instructions for manual updates if the maximum retry attempts are exceeded.

### Other changes:

* [`install.ps1`](diffhunk://#diff-50d51a233d8ff4886061fc5cf1a03642de1f64b3625903e4f876e8cd2a3f5806L3-R7): Updated the ASCII art in the Windows installation script to a more readable format.