### PR TITLE
fixed add-docs for documents and website

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ bin/
 hook-executed.log
 rlama.exe
 *.exe
+tests/

--- a/hook-executed.log
+++ b/hook-executed.log
@@ -1,1 +1,1 @@
-Hook exécuté à Fri Mar 21 11:47:40 EDT 2025
+Hook exécuté à Sat Mar 22 14:04:02 EDT 2025

--- a/tests/e2e/test_helpers.go
+++ b/tests/e2e/test_helpers.go
@@ -1,6 +1,8 @@
 package tests
 
 import (
+	"reflect"
+
 	"github.com/dontizi/rlama/internal/client"
 	"github.com/dontizi/rlama/internal/domain"
 	"github.com/dontizi/rlama/internal/repository"
@@ -49,6 +51,108 @@ func (m *MockEmbeddingService) GenerateQueryEmbedding(query string, modelName st
 
 func (m *MockEmbeddingService) GetOllamaClient() *client.OllamaClient {
 	return nil
+}
+
+// MockBGERerankerClient simule le client BGE Reranker
+type MockBGERerankerClient struct {
+	mock.Mock
+}
+
+func (m *MockBGERerankerClient) GetModelName() string {
+	args := m.Called()
+	return args.String(0)
+}
+
+func (m *MockBGERerankerClient) ComputeScores(pairs [][]string, normalize bool) ([]float64, error) {
+	args := m.Called(pairs, normalize)
+	return args.Get(0).([]float64), args.Error(1)
+}
+
+func (m *MockBGERerankerClient) CheckDependencies() error {
+	args := m.Called()
+	return args.Error(0)
+}
+
+func (m *MockBGERerankerClient) CheckModelExists() error {
+	args := m.Called()
+	return args.Error(0)
+}
+
+// NewMockRerankerService crée un RerankerService utilisant un mock BGERerankerClient
+func NewMockRerankerService(ollamaClient *client.OllamaClient, mockBGEClient *MockBGERerankerClient) *service.RerankerService {
+	// Créer une structure RerankerService avec des champs privés
+	rerankerService := &service.RerankerService{}
+
+	// Utiliser reflect pour accéder aux champs privés et les modifier
+	serviceValue := reflect.ValueOf(rerankerService).Elem()
+
+	// Remplacer le client Ollama
+	ollamaField := serviceValue.FieldByName("ollamaClient")
+	if ollamaField.IsValid() && ollamaField.CanSet() {
+		ollamaField.Set(reflect.ValueOf(ollamaClient))
+	}
+
+	// Remplacer le client BGE Reranker par notre mock
+	bgeField := serviceValue.FieldByName("bgeRerankerClient")
+	if bgeField.IsValid() && bgeField.CanSet() {
+		// Cast le MockBGERerankerClient à client.BGERerankerClient via interface{}
+		bgeField.Set(reflect.ValueOf(mockBGEClient))
+	}
+
+	return rerankerService
+}
+
+// NewRagServiceWithMockReranker crée un RagService avec un RerankerService utilisant un mock BGERerankerClient
+func NewRagServiceWithMockReranker(ollamaClient *client.OllamaClient, embeddingService *service.EmbeddingService, mockBGEClient *MockBGERerankerClient) service.RagService {
+	if ollamaClient == nil {
+		ollamaClient = client.NewDefaultOllamaClient()
+	}
+
+	// Créer un RagService standard
+	ragService := &service.RagServiceImpl{}
+
+	// Utiliser reflect pour accéder aux champs privés
+	serviceValue := reflect.ValueOf(ragService).Elem()
+
+	// Configurer les services
+	if embeddingService != nil {
+		embedField := serviceValue.FieldByName("embeddingService")
+		if embedField.IsValid() && embedField.CanSet() {
+			embedField.Set(reflect.ValueOf(embeddingService))
+		}
+	} else {
+		embedField := serviceValue.FieldByName("embeddingService")
+		if embedField.IsValid() && embedField.CanSet() {
+			embedField.Set(reflect.ValueOf(service.NewEmbeddingService(ollamaClient)))
+		}
+	}
+
+	// Configurer le client Ollama
+	ollamaField := serviceValue.FieldByName("ollamaClient")
+	if ollamaField.IsValid() && ollamaField.CanSet() {
+		ollamaField.Set(reflect.ValueOf(ollamaClient))
+	}
+
+	// Configurer le DocumentLoader
+	loaderField := serviceValue.FieldByName("documentLoader")
+	if loaderField.IsValid() && loaderField.CanSet() {
+		loaderField.Set(reflect.ValueOf(service.NewDocumentLoader()))
+	}
+
+	// Configurer le RagRepository
+	repoField := serviceValue.FieldByName("ragRepository")
+	if repoField.IsValid() && repoField.CanSet() {
+		repoField.Set(reflect.ValueOf(repository.NewRagRepository()))
+	}
+
+	// Configurer le RerankerService avec notre mock
+	rerankerService := NewMockRerankerService(ollamaClient, mockBGEClient)
+	rerankerField := serviceValue.FieldByName("rerankerService")
+	if rerankerField.IsValid() && rerankerField.CanSet() {
+		rerankerField.Set(reflect.ValueOf(rerankerService))
+	}
+
+	return ragService
 }
 
 // TestRagService est une implémentation de test du service RAG
@@ -104,4 +208,92 @@ func (s *TestRagService) DeleteRag(ragName string) error {
 
 func (s *TestRagService) ListRags() ([]string, error) {
 	return []string{"test-rag"}, nil
+}
+
+// Ajouter les méthodes manquantes pour l'interface RagService
+
+func (s *TestRagService) GetRagChunks(ragName string, filter service.ChunkFilter) ([]*domain.DocumentChunk, error) {
+	// Mock pour retourner quelques chunks de test
+	chunks := []*domain.DocumentChunk{
+		{
+			ID:          "test-chunk-1",
+			DocumentID:  "test-doc-1",
+			Content:     "This is test content 1",
+			ChunkNumber: 0,
+			TotalChunks: 2,
+		},
+		{
+			ID:          "test-chunk-2",
+			DocumentID:  "test-doc-1",
+			Content:     "This is test content 2",
+			ChunkNumber: 1,
+			TotalChunks: 2,
+		},
+	}
+	return chunks, nil
+}
+
+func (s *TestRagService) Query(rag *domain.RagSystem, query string, contextSize int) (string, error) {
+	// Vérifier le modèle avec CheckLLMAndModel (important pour satisfaire l'expectation du mock)
+	if err := s.mockOllama.CheckLLMAndModel(rag.ModelName); err != nil {
+		return "", err
+	}
+
+	// Simuler une réponse en utilisant notre mock ollama client
+	return s.mockOllama.GenerateCompletion("any-model", "any-prompt")
+}
+
+func (s *TestRagService) AddDocsWithOptions(ragName string, folderPath string, options service.DocumentLoaderOptions) error {
+	// Mock implémentation simple
+	return nil
+}
+
+func (s *TestRagService) UpdateModel(ragName string, newModel string) error {
+	// Mock implémentation simple
+	return nil
+}
+
+func (s *TestRagService) UpdateRag(rag *domain.RagSystem) error {
+	// Mock implémentation simple pour sauvegarder le RAG modifié
+	return s.ragRepository.Save(rag)
+}
+
+func (s *TestRagService) UpdateRerankerModel(ragName string, model string) error {
+	// Mock implémentation simple
+	return nil
+}
+
+func (s *TestRagService) ListAllRags() ([]string, error) {
+	return []string{"test-rag"}, nil
+}
+
+func (s *TestRagService) GetOllamaClient() *client.OllamaClient {
+	// Ce mock ne possède pas un vrai client Ollama
+	return nil
+}
+
+// Méthodes liées au directory watching
+func (s *TestRagService) SetupDirectoryWatching(ragName string, dirPath string, watchInterval int, options service.DocumentLoaderOptions) error {
+	return nil
+}
+
+func (s *TestRagService) DisableDirectoryWatching(ragName string) error {
+	return nil
+}
+
+func (s *TestRagService) CheckWatchedDirectory(ragName string) (int, error) {
+	return 0, nil
+}
+
+// Méthodes liées au web watching
+func (s *TestRagService) SetupWebWatching(ragName string, websiteURL string, watchInterval int, options domain.WebWatchOptions) error {
+	return nil
+}
+
+func (s *TestRagService) DisableWebWatching(ragName string) error {
+	return nil
+}
+
+func (s *TestRagService) CheckWatchedWebsite(ragName string) (int, error) {
+	return 0, nil
 }


### PR DESCRIPTION
This pull request introduces several enhancements to the document crawling and reranking features, along with updates to the RAG (Retrieval-Augmented Generation) service and its tests. The changes include the addition of new flags for controlling crawling behavior, updates to the RAG service to handle document loading and chunking, and the use of mock clients in tests for better test isolation and reliability.

### Enhancements to crawling behavior:
* Added new flags for chunk size, chunk overlap, chunking strategy, and reranking options in `cmd/crawl_add_docs.go`. [[1]](diffhunk://#diff-324171ed7d901ab51fbb491dd0e33a6e5e4040c4a0730b4481b60c810010a5edR17-R22) [[2]](diffhunk://#diff-324171ed7d901ab51fbb491dd0e33a6e5e4040c4a0730b4481b60c810010a5edL32-R44) [[3]](diffhunk://#diff-324171ed7d901ab51fbb491dd0e33a6e5e4040c4a0730b4481b60c810010a5edL87-R104) [[4]](diffhunk://#diff-324171ed7d901ab51fbb491dd0e33a6e5e4040c4a0730b4481b60c810010a5edL112-R137)

### Updates to RAG service:
* Implemented document loading with options, chunking, and reranking in `internal/service/rag_service.go`.

### Improvements in testing:
* Replaced the real Ollama client with a mock client in `tests/e2e/rag_service_test.go` to improve test reliability. [[1]](diffhunk://#diff-55ac457d783c7c786da5a2bd7c17f75b5e9308c26d16efbf86ea86d7c56d839eL8-R11) [[2]](diffhunk://#diff-55ac457d783c7c786da5a2bd7c17f75b5e9308c26d16efbf86ea86d7c56d839eL41-R70) [[3]](diffhunk://#diff-55ac457d783c7c786da5a2bd7c17f75b5e9308c26d16efbf86ea86d7c56d839eL62-R81) [[4]](diffhunk://#diff-55ac457d783c7c786da5a2bd7c17f75b5e9308c26d16efbf86ea86d7c56d839eL71-R120)
* Added a mock BGERerankerClient and helper functions for creating services with mocks in `tests/e2e/test_helpers.go`. [[1]](diffhunk://#diff-62ed1d52efa8485f0049a302a768cae7e7777a984dc5c570ed0b1d7401aeced2R4-R5) [[2]](diffhunk://#diff-62ed1d52efa8485f0049a302a768cae7e7777a984dc5c570ed0b1d7401aeced2R56-R157) [[3]](diffhunk://#diff-62ed1d52efa8485f0049a302a768cae7e7777a984dc5c570ed0b1d7401aeced2R212-R299)