### PR TITLE
adding webcrawling for single url , sitemap , or specific urls

### DIFF
--- a/cmd/crawl_add_docs.go
+++ b/cmd/crawl_add_docs.go
@@ -14,6 +14,8 @@ var (
 	addCrawlConcurrency      int
 	addCrawlExcludePaths     []string
 	addCrawlUseSitemap       bool
+	addCrawlSingleURL        bool
+	addCrawlURLsList         []string
 	addCrawlChunkSize        int
 	addCrawlChunkOverlap     int
 	addCrawlChunkingStrategy string
@@ -36,6 +38,8 @@ Control the crawling behavior with these flags:
   --concurrency=10      Number of concurrent crawlers
   --exclude-path=/tag   Skip specific path patterns (comma-separated)
   --use-sitemap         Use sitemap.xml if available for comprehensive coverage
+  --single-url          Process only the specified URL without following links
+  --urls-list=url1,url2 Provide a comma-separated list of specific URLs to crawl
   --chunk-size=1000     Character count per chunk
   --chunk-overlap=200   Overlap between chunks in characters
   --chunking-strategy=hybrid  Chunking strategy to use (fixed, semantic, hybrid, hierarchical)
@@ -65,8 +69,25 @@ Control the crawling behavior with these flags:
 			return fmt.Errorf("error initializing web crawler: %w", err)
 		}
 
-		// Définir l'option de sitemap
+		// Définir les options de crawling
 		webCrawler.SetUseSitemap(addCrawlUseSitemap)
+		webCrawler.SetSingleURLMode(addCrawlSingleURL)
+
+		// Si liste d'URLs spécifiques, la définir
+		if len(addCrawlURLsList) > 0 {
+			webCrawler.SetURLsList(addCrawlURLsList)
+		}
+
+		// Afficher le mode de crawling
+		if len(addCrawlURLsList) > 0 {
+			fmt.Printf("URLs list mode: crawling %d specific URLs\n", len(addCrawlURLsList))
+		} else if addCrawlSingleURL {
+			fmt.Println("Single URL mode: only the specified URL will be crawled (no links will be followed)")
+		} else if addCrawlUseSitemap {
+			fmt.Println("Sitemap mode enabled: will try to use sitemap.xml for comprehensive coverage")
+		} else {
+			fmt.Println("Standard crawling mode: will follow links to the specified depth")
+		}
 
 		fmt.Printf("Crawling website '%s' to add content to RAG '%s'...\n", websiteURL, ragName)
 
@@ -123,6 +144,8 @@ func init() {
 	crawlAddDocsCmd.Flags().IntVar(&addCrawlConcurrency, "concurrency", 5, "Number of concurrent crawlers")
 	crawlAddDocsCmd.Flags().StringSliceVar(&addCrawlExcludePaths, "exclude-path", nil, "Paths to exclude from crawling (comma-separated)")
 	crawlAddDocsCmd.Flags().BoolVar(&addCrawlUseSitemap, "use-sitemap", true, "Use sitemap.xml if available for comprehensive coverage")
+	crawlAddDocsCmd.Flags().BoolVar(&addCrawlSingleURL, "single-url", false, "Process only the specified URL without following links")
+	crawlAddDocsCmd.Flags().StringSliceVar(&addCrawlURLsList, "urls-list", nil, "Provide a comma-separated list of specific URLs to crawl")
 
 	// Add chunking flags
 	crawlAddDocsCmd.Flags().IntVar(&addCrawlChunkSize, "chunk-size", 1000, "Character count per chunk (default: 1000)")


### PR DESCRIPTION
This pull request introduces new features to the web crawler, adding options for processing a single URL and a list of specific URLs. These changes enhance the flexibility and control over the crawling behavior. The most important changes include updates to the command-line flags, modifications to the `WebCrawler` struct, and the implementation of new methods for handling the new crawling modes.

### New Features for Crawling:

* [`cmd/crawl_add_docs.go`](diffhunk://#diff-324171ed7d901ab51fbb491dd0e33a6e5e4040c4a0730b4481b60c810010a5edR17-R18): Added new command-line flags `--single-url` and `--urls-list` to control the crawling behavior. These flags allow processing only a specified URL or a list of specific URLs. [[1]](diffhunk://#diff-324171ed7d901ab51fbb491dd0e33a6e5e4040c4a0730b4481b60c810010a5edR17-R18) [[2]](diffhunk://#diff-324171ed7d901ab51fbb491dd0e33a6e5e4040c4a0730b4481b60c810010a5edR41-R42) [[3]](diffhunk://#diff-324171ed7d901ab51fbb491dd0e33a6e5e4040c4a0730b4481b60c810010a5edL68-R90) [[4]](diffhunk://#diff-324171ed7d901ab51fbb491dd0e33a6e5e4040c4a0730b4481b60c810010a5edR147-R148)
* [`cmd/crawl_rag.go`](diffhunk://#diff-021b21dc39e5ad5d03624392d4f569fed999c8edccb2d22e157ece790cfbb302R19-L22): Updated to include the new flags `--single-url` and `--urls-list` for similar functionality in the RAG crawling command. [[1]](diffhunk://#diff-021b21dc39e5ad5d03624392d4f569fed999c8edccb2d22e157ece790cfbb302R19-L22) [[2]](diffhunk://#diff-021b21dc39e5ad5d03624392d4f569fed999c8edccb2d22e157ece790cfbb302L56-R76) [[3]](diffhunk://#diff-021b21dc39e5ad5d03624392d4f569fed999c8edccb2d22e157ece790cfbb302R147-R148)

### Modifications to `WebCrawler`:

* [`internal/crawler/crawler.go`](diffhunk://#diff-4b16ae3250117a18bb13dadcb64ff113bb330dc0f124f81f9a5fb2d6b16c638bL25-R27): Added new fields `singleURL` and `urlsList` to the `WebCrawler` struct to store the state for the new crawling modes. [[1]](diffhunk://#diff-4b16ae3250117a18bb13dadcb64ff113bb330dc0f124f81f9a5fb2d6b16c638bL25-R27) [[2]](diffhunk://#diff-4b16ae3250117a18bb13dadcb64ff113bb330dc0f124f81f9a5fb2d6b16c638bR45-R46)
* [`internal/crawler/crawler.go`](diffhunk://#diff-4b16ae3250117a18bb13dadcb64ff113bb330dc0f124f81f9a5fb2d6b16c638bR72-R82): Implemented new methods `crawlSingleURL` and `crawlURLsList` to handle the crawling logic for a single URL and a list of URLs, respectively. [[1]](diffhunk://#diff-4b16ae3250117a18bb13dadcb64ff113bb330dc0f124f81f9a5fb2d6b16c638bR72-R82) [[2]](diffhunk://#diff-4b16ae3250117a18bb13dadcb64ff113bb330dc0f124f81f9a5fb2d6b16c638bR104-R179)
* [`internal/crawler/crawler.go`](diffhunk://#diff-4b16ae3250117a18bb13dadcb64ff113bb330dc0f124f81f9a5fb2d6b16c638bR393-R402): Added setter methods `SetSingleURLMode` and `SetURLsList` to configure the `WebCrawler` instance for the new modes.