### PR TITLE
fixed add-docs for documents and website

### DIFF
--- a/internal/crawler/crawler.go
+++ b/internal/crawler/crawler.go
@@ -203,7 +203,15 @@ func (wc *WebCrawler) crawlStandard() ([]domain.Document, error) {
 		}
 
 		// Don't crawl deeper if we've reached the maximum depth
-		urlDepth := strings.Count(url[len(wc.baseURL.String()):], "/")
+		urlStr := url
+		baseURLStr := wc.baseURL.String()
+
+		// Prevent panic when url length is less than baseURL length
+		urlDepth := 0
+		if len(urlStr) > len(baseURLStr) {
+			urlDepth = strings.Count(urlStr[len(baseURLStr):], "/")
+		}
+
 		if urlDepth >= wc.maxDepth {
 			continue
 		}


### PR DESCRIPTION
This pull request includes several enhancements and new features to the `cmd/wizard.go` file, focusing on improving the configuration and setup process for web crawling and directory watching. Additionally, there is a bug fix in `internal/crawler/crawler.go` to prevent a potential panic.

Enhancements and new features:

* [`cmd/wizard.go`](diffhunk://#diff-c2f7d950373c95aa749e90baf517a7f8030edb1e22af5a08aba01a9501b660cbR175-R176): Added options for single URL crawling and specific URLs list. This includes prompts to configure these options and display the crawling configuration. [[1]](diffhunk://#diff-c2f7d950373c95aa749e90baf517a7f8030edb1e22af5a08aba01a9501b660cbR175-R176) [[2]](diffhunk://#diff-c2f7d950373c95aa749e90baf517a7f8030edb1e22af5a08aba01a9501b660cbR228-R265) [[3]](diffhunk://#diff-c2f7d950373c95aa749e90baf517a7f8030edb1e22af5a08aba01a9501b660cbR359-R366)
* [`cmd/wizard.go`](diffhunk://#diff-c2f7d950373c95aa749e90baf517a7f8030edb1e22af5a08aba01a9501b660cbR490-R581): Implemented directory watching setup for local folder RAGs and website watching setup for web crawler RAGs, including prompts for user confirmation and interval configuration.

Bug fix:

* [`internal/crawler/crawler.go`](diffhunk://#diff-4b16ae3250117a18bb13dadcb64ff113bb330dc0f124f81f9a5fb2d6b16c638bL206-R214): Fixed an issue where attempting to calculate URL depth could cause a panic if the URL length was shorter than the base URL length.