### PR TITLE
Fix url depth check out of bounds panic

### DIFF
--- a/internal/crawler/crawler.go
+++ b/internal/crawler/crawler.go
@@ -203,8 +203,9 @@ func (wc *WebCrawler) crawlStandard() ([]domain.Document, error) {
 		}
 
 		// Don't crawl deeper if we've reached the maximum depth
-		urlDepth := strings.Count(url[len(wc.baseURL.String()):], "/")
-		if urlDepth >= wc.maxDepth {
+		urlDepth := strings.Count(url, "/")
+		baseDepth := strings.Count(wc.baseURL.String(), "/")
+		if urlDepth-baseDepth >= wc.maxDepth {
 			continue
 		}
 


### PR DESCRIPTION
Fixes #81 

Tested with the same website as described in the issue with depth of 2.
Now just compares number of baseurl '/'s against the current '/' count of the URL to the document is greater than the max depth.